### PR TITLE
Python3

### DIFF
--- a/bin/ppath
+++ b/bin/ppath
@@ -10,7 +10,7 @@ from os import sep
 
 from pairtree import id_encode, id_decode
 
-from StringIO import StringIO
+from io import StringIO
 
 def _option_parser():
     parser = optparse.OptionParser()
@@ -46,7 +46,7 @@ if __name__ == '__main__':
             encodedid = encodedid[2:]
         if path:
             filepath.append(path)
-        print j(*filepath)
+        print(j(*filepath))
     elif cmd == 'toid':
         if len(args) == 1:
             sys.exit("Need to pass a filepath to this command")
@@ -77,10 +77,10 @@ if __name__ == '__main__':
         remnants = tokens[index:]
         if remnants:
             ident = j(ident, *remnants)
-        print ident
+        print(ident)
     elif cmd == 'help' or cmd == "":
-        print "ppath topath [id] - converts an id or id/subpath into a pairtree directory path"
-        print "ppath toid [path] - converts a filepath into an id or id/subpath"
+        print("ppath topath [id] - converts an id or id/subpath into a pairtree directory path")
+        print("ppath toid [path] - converts a filepath into an id or id/subpath")
     elif len(args) == 1:
         # Assume topath - eg ppath foo:1 -> reads as -> ppath topath foo:1
         frags = args[0].split(sep, 1)
@@ -96,9 +96,9 @@ if __name__ == '__main__':
             encodedid = encodedid[2:]
         if path:
             filepath.append(path)
-        print j(*filepath)
+        print(j(*filepath))
     else:
-        print "unknown command: %s" % cmd
-        print "ppath topath [id] - converts an id or id/subpath into a pairtree directory path"
-        print "ppath toid [path] - converts a filepath into an id or id/subpath"
+        print("unknown command: %s" % cmd)
+        print("ppath topath [id] - converts an id or id/subpath into a pairtree directory path")
+        print("ppath toid [path] - converts a filepath into an id or id/subpath")
 

--- a/examples/basics.py
+++ b/examples/basics.py
@@ -20,11 +20,11 @@ foobar = store.get_object('foobar')
 # Add a byte sequence
 md5hash = foobar.add_bytestream('foobar.txt', """Can just be an in memory string of bytes""")
 
-print "%s hash of foobar.txt = %s" % (md5hash)
+print("%s hash of foobar.txt = %s" % (md5hash))
 
 # Faking a file handle to a large file we'd rather streamed than copy into
 # memory
-from StringIO import StringIO
+from io import StringIO
 handle_to_large_file = StringIO()
 handle_to_large_file.write('Foo bar foo bar foo bar foo bar foo bar foo bar')
 handle_to_large_file.seek(0)
@@ -34,9 +34,9 @@ handle_to_large_file.seek(0)
 # call it 'large_file.txt'
 md5hash = foobar.add_bytestream('large_file.txt', handle_to_large_file)
 
-print "%s hash of large file = %s" % (md5hash)
+print("%s hash of large file = %s" % (md5hash))
 
-print foobar.list_parts()
+print(foobar.list_parts())
 
 # Create a file on disc
 fn = open('/tmp/foo.txt', 'w')
@@ -45,18 +45,18 @@ fn.close()
 
 # stream file from on disc location into the pairtree object
 # but put it into a 'data/mine' directory
-print "%s file hash = %s" % (foobar.add_file('/tmp/foo.txt', 'data/mine'))
+print("%s file hash = %s" % (foobar.add_file('/tmp/foo.txt', 'data/mine')))
 
 # create a new object to test 'split-end' handling
 foobartoo = store.create_object('foobartoo')
-print "foomanchu.txt - %s: %s" % (foobartoo.add_bytestream('foomanchu.txt', 'Nothing to see here. Move along'))
+print("foomanchu.txt - %s: %s" % (foobartoo.add_bytestream('foomanchu.txt', 'Nothing to see here. Move along')))
 
 # Results should be mostly unchanged from before
 # with the only addition being the data directory
-print foobar.list_parts()
+print(foobar.list_parts())
 
 # Results should just be foomanchu.txt
-print foobartoo.list_parts()
+print(foobartoo.list_parts())
 
 # create a new object to test recursive path deletion
 # in objects

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -14,7 +14,7 @@ the appropriate options to ``use_setuptools()``.
 This file can also be run as a script to install or upgrade setuptools.
 """
 import sys
-DEFAULT_VERSION = "5.4.1"
+DEFAULT_VERSION = "0.6c9"
 DEFAULT_URL     = "http://pypi.python.org/packages/%s/s/setuptools/" % sys.version[:3]
 
 md5_data = {

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -13,6 +13,7 @@ the appropriate options to ``use_setuptools()``.
 
 This file can also be run as a script to install or upgrade setuptools.
 """
+from __future__ import print_function
 import sys
 DEFAULT_VERSION = "0.6c9"
 DEFAULT_URL     = "http://pypi.python.org/packages/%s/s/setuptools/" % sys.version[:3]

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -62,10 +62,10 @@ def _validate_md5(egg_name, data):
     if egg_name in md5_data:
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
-            print >>sys.stderr, (
+            print((
                 "md5 validation of %s failed!  (Possible download problem?)"
                 % egg_name
-            )
+            ), file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -95,14 +95,14 @@ def use_setuptools(
         return do_download()       
     try:
         pkg_resources.require("setuptools>="+version); return
-    except pkg_resources.VersionConflict, e:
+    except pkg_resources.VersionConflict as e:
         if was_imported:
-            print >>sys.stderr, (
+            print((
             "The required version of setuptools (>=%s) is not available, and\n"
             "can't be installed while this script is running. Please install\n"
             " a more recent version first, using 'easy_install -U setuptools'."
             "\n\n(Currently using %r)"
-            ) % (version, e.args[0])
+            ) % (version, e.args[0]), file=sys.stderr)
             sys.exit(2)
         else:
             del pkg_resources, sys.modules['pkg_resources']    # reload ok
@@ -121,7 +121,7 @@ def download_setuptools(
     with a '/'). `to_dir` is the directory where the egg will be downloaded.
     `delay` is the number of seconds to pause before an actual download attempt.
     """
-    import urllib2, shutil
+    import urllib.request, urllib.error, urllib.parse, shutil
     egg_name = "setuptools-%s-py%s.egg" % (version,sys.version[:3])
     url = download_base + egg_name
     saveto = os.path.join(to_dir, egg_name)
@@ -147,7 +147,7 @@ and place it in this directory before rerunning this script.)
                     version, download_base, delay, url
                 ); from time import sleep; sleep(delay)
             log.warn("Downloading %s", url)
-            src = urllib2.urlopen(url)
+            src = urllib.request.urlopen(url)
             # Read/write all in one block, so we don't create a corrupt file
             # if the download is interrupted.
             data = _validate_md5(egg_name, src.read())
@@ -173,10 +173,10 @@ def main(argv, version=DEFAULT_VERSION):
                 os.unlink(egg)
     else:
         if setuptools.__version__ == '0.0.1':
-            print >>sys.stderr, (
+            print((
             "You have an obsolete version of setuptools installed.  Please\n"
             "remove it from your system entirely before rerunning this script."
-            )
+            ), file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version
@@ -195,8 +195,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print "Setuptools version",version,"or greater has been installed."
-            print '(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)'
+            print("Setuptools version",version,"or greater has been installed.")
+            print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):
     """Update our built-in md5 registry"""
@@ -209,7 +209,7 @@ def update_md5(filenames):
         md5_data[base] = md5(f.read()).hexdigest()
         f.close()
 
-    data = ["    %r: %r,\n" % it for it in md5_data.items()]
+    data = ["    %r: %r,\n" % it for it in list(md5_data.items())]
     data.sort()
     repl = "".join(data)
 
@@ -219,7 +219,7 @@ def update_md5(filenames):
 
     match = re.search("\nmd5_data = {\n([^}]+)}", src)
     if not match:
-        print >>sys.stderr, "Internal error!"
+        print("Internal error!", file=sys.stderr)
         sys.exit(2)
 
     src = src[:match.start(1)] + repl + src[match.end(1):]

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -14,7 +14,7 @@ the appropriate options to ``use_setuptools()``.
 This file can also be run as a script to install or upgrade setuptools.
 """
 import sys
-DEFAULT_VERSION = "0.6c9"
+DEFAULT_VERSION = "5.4.1"
 DEFAULT_URL     = "http://pypi.python.org/packages/%s/s/setuptools/" % sys.version[:3]
 
 md5_data = {

--- a/pairtree/__init__.py
+++ b/pairtree/__init__.py
@@ -190,13 +190,13 @@ can be any sequence of bytes
 
 __version__ = '0.5.2'
 
-from pairtree_client import *
-from pairtree_store import *
-from pairtree_object import *
-from pairtree_revlookup import PairtreeReverseLookup
-import pairtree_path as ppath
-from pairtree_path import id_encode, id_decode
-from storage_exceptions import *
+from .pairtree_client import *
+from .pairtree_store import *
+from .pairtree_object import *
+from .pairtree_revlookup import PairtreeReverseLookup
+from . import pairtree_path as ppath
+from .pairtree_path import id_encode, id_decode
+from .storage_exceptions import *
 
 def id2path(id):
     """

--- a/pairtree/pairtree_client.py
+++ b/pairtree/pairtree_client.py
@@ -31,11 +31,11 @@ import random
 
 import re
 
-from storage_exceptions import *
+from .storage_exceptions import *
 
-from pairtree_object import PairtreeStorageObject
+from .pairtree_object import PairtreeStorageObject
 
-import pairtree_path as ppath
+from . import pairtree_path as ppath
 
 import hashlib
 
@@ -450,7 +450,7 @@ class PairtreeStorageClient(object):
                 f.write(bytestream)
                 if self.hashing_type != None:
                     hash_gen.update(bytestream)
-        except Exception, e:
+        except Exception as e:
             logger.info("put_stream failed: %s" % e)
         f.close()
         if self.hashing_type != None:

--- a/pairtree/pairtree_object.py
+++ b/pairtree/pairtree_object.py
@@ -11,8 +11,8 @@ As such, it shouldn't be instanciated directly.
 """
 
 import os
-from storage_exceptions import *
-import myutils
+from .storage_exceptions import *
+from . import myutils
 
 
 class PairtreeStorageObject(object):

--- a/pairtree/pairtree_path.py
+++ b/pairtree/pairtree_path.py
@@ -25,8 +25,6 @@ import os, sys, shutil
 
 import binascii
 
-import string
-
 import re
 
 from .storage_exceptions import *
@@ -39,8 +37,15 @@ logger = logging.getLogger('pairtreepath')
 
 
 PASS1_MATCHES = ['"', '*', '+', ",", '<', '=', '>', '?', '\\', '^', '|']
-PASS2_MAP = str.maketrans('/:.', '=+,')
-REV_PASS2_MAP = str.maketrans('=+,', '/:.')
+if sys.version_info.major >= 3:
+    # for Python 3
+    PASS2_MAP = str.maketrans('/:.', '=+,')
+    REV_PASS2_MAP = str.maketrans('=+,', '/:.')
+else:
+    # for Python 2
+    import string
+    PASS2_MAP = string.maketrans('/:.', '=+,')
+    REV_PASS2_MAP = string.maketrans('=+,', '/:.')
 
 def first_pass(id):
     clean = []
@@ -60,8 +65,14 @@ def ascii2hex(char):
     return "^%02x" % ord(char)
 
 def uni2hex(char):
-    char = char.encode('utf-8')
-    return str(char)[2:-1].replace('\\x', '^')
+    if sys.version_info.major >= 3:
+        # for Python3
+        codes = char.encode('utf-8')
+        return str(codes)[2:-1].replace('\\x', '^')
+    else:
+        # for Python2
+        codes = ["^%02x" % ord(c) for c in char]
+        return "".join(codes)
 
 
 def reverse_second_pass(id):
@@ -101,8 +112,14 @@ def hex2ascii(code):
     return chr(int(code, 16))
 
 def hex2uni(codes):
-    return binascii.unhexlify(codes).decode('utf-8')
-
+    codes = binascii.unhexlify(codes)
+    uni =  codes.decode('utf-8')
+    if sys.version_info.major >= 3:
+        # for Python3
+        return uni
+    else:
+        # for Python 2
+        return codes
 
 def id_encode(id):
     """

--- a/pairtree/pairtree_path.py
+++ b/pairtree/pairtree_path.py
@@ -29,7 +29,7 @@ import string
 
 import re
 
-from storage_exceptions import *
+from .storage_exceptions import *
 
 import logging
 
@@ -94,7 +94,7 @@ def id_encode(id):
     @returns: A string of the encoded identifier
     """
     # Unicode or bust
-    if isinstance(id, unicode):
+    if isinstance(id, str):
         # assume utf-8
         # TODO - not assume encoding
         id = id.encode('utf-8')

--- a/pairtree/pairtree_path.py
+++ b/pairtree/pairtree_path.py
@@ -68,37 +68,40 @@ def reverse_second_pass(id):
     return id.translate(REV_PASS2_MAP)
 
 def reverse_first_pass(id):
-    i = 0
+    index = 0
     new_id = []
-    while i < len(id):
-        if id[i] == '^':
-            hexcode = id[i+1:i+3]
+    while index < len(id):
+        numchar = 1 # number of characters to read
+        if id[index] == '^':
+            hexcode = get_hexcode(id, index, numchar)
             if int(hexcode, 16) < 127:
                 new_id.append(hex2ascii(hexcode))
-                i += 3
+                index += 3
             else:
-                nb = 2 # number of bytes
                 while True:
-                    hexcode = id[i:i+nb*3]
+                    numchar += 1
+                    hexcode = get_hexcode(id, index, numchar)
                     try:
                         new_id.append(hex2uni(hexcode))
-                        i += nb*3
+                        index += numchar*3
                         break
                     except UnicodeDecodeError:
-                        nb += 1
-                        if nb > 6:
+                        if numchar == 6:
                             raise
         else:
-            new_id.append(id[i])
-            i += 1
+            new_id.append(id[index])
+            index += 1
     return "".join(new_id)
+
+def get_hexcode(id, start, numchar):
+    hexcode = id[start: start+numchar*3]
+    return hexcode.replace('^', '')
 
 def hex2ascii(code):
     return chr(int(code, 16))
 
-def hex2uni(code):
-    code = code.replace('^', '')
-    return binascii.unhexlify(code).decode('utf-8')
+def hex2uni(codes):
+    return binascii.unhexlify(codes).decode('utf-8')
 
 
 def id_encode(id):

--- a/pairtree/pairtree_revlookup.py
+++ b/pairtree/pairtree_revlookup.py
@@ -39,11 +39,11 @@ This was created to avoid certain race conditions I had with a pickled dictionar
 A sqllite or similar lookup would also be effective, but this one relies solely on pairtree.
 """
 
-from __future__ import with_statement
+
 
 import os
 
-from pairtree_path import id_encode, id_decode, get_id_from_dirpath, get_path_from_dirpath, id_to_dirpath
+from .pairtree_path import id_encode, id_decode, get_id_from_dirpath, get_path_from_dirpath, id_to_dirpath
 
 PAIRTREE_RL = "pairtree_rl"
 

--- a/pairtree/pairtree_store.py
+++ b/pairtree/pairtree_store.py
@@ -24,7 +24,7 @@ I{http://example.org/ark:/123}
 
 """
 
-from pairtree_client import PairtreeStorageClient
+from .pairtree_client import PairtreeStorageClient
 
 class PairtreeStorageFactory(object):
 

--- a/pairtree/storage_exceptions.py
+++ b/pairtree/storage_exceptions.py
@@ -11,7 +11,7 @@ class PartNotFoundException(Exception):
     def __init__(self, *p, **kw):
         self.context = (p, kw)
     def __str__(self):
-        print " - Part not found: %s" % self.context
+        print(" - Part not found: %s" % self.context)
 
 class StoreNotFoundException(Exception):
     """Store not found"""

--- a/tests/test.py
+++ b/tests/test.py
@@ -133,14 +133,14 @@ class TestPairtree(unittest.TestCase):
         self.roundtrip('asdfghjklpoiuytrewqxcvbnm1234567890:;/', 'Basic Roundtrip')
 
     def test_french_roundtrip(self):
-        self.roundtrip(u'Années de Pèlerinage', 'French Unicode roundtrip')
+        self.roundtrip('Années de Pèlerinage', 'French Unicode roundtrip')
 
     def test_japanese_rountrip(self):
-        self.roundtrip(u'ウインカリッスの日本語', 'Japanese Unicode roundtrip')
+        self.roundtrip('ウインカリッスの日本語', 'Japanese Unicode roundtrip')
         
     def test_hardcore_unicode_rountrip(self):
         # If this works...
-        self.roundtrip(u"""   1. Euro Symbol: €.
+        self.roundtrip("""   1. Euro Symbol: €.
    2. Greek: Μπορώ να φάω σπασμένα γυαλιά χωρίς να πάθω τίποτα.
    3. Íslenska / Icelandic: Ég get etið gler án þess að meiða mig.
    4. Polish: Mogę jeść szkło, i mi nie szkodzi.


### PR DESCRIPTION
I have made some changes to make this package work with Python3.  However, it is not backwards compatible with Python2 so it will need to live in a separate branch until I manage to make it work for both.

I used the 2to3 utility for the bulk of the changes. But I also had to hack away at the pairtree_path.py module. The elegant regex solution doesn't work well in Python3 because you can't mix bytes with unicode. I think my solution could be improved upon, but for now it works and passes all tests.
